### PR TITLE
fix for case where lookup with array containing non-existent dimension v...

### DIFF
--- a/supergroup.js
+++ b/supergroup.js
@@ -162,6 +162,9 @@ var supergroup = (function() {
             var ret;
             while(values.length) {
                 ret = list.singleLookup(values.shift());
+                if(!ret) {
+                    break;
+                }                
                 list = ret[childProp];
             }
             return ret;


### PR DESCRIPTION
...alue caused an error because ret is undefined